### PR TITLE
Use open3 for shell command execution

### DIFF
--- a/lib/soxi/wrapper.rb
+++ b/lib/soxi/wrapper.rb
@@ -1,5 +1,6 @@
 require "soxi/wrapper/version"
 require "soxi/wrapper/file"
+require 'open3'
 
 module Soxi
   module Wrapper

--- a/lib/soxi/wrapper/file.rb
+++ b/lib/soxi/wrapper/file.rb
@@ -49,11 +49,14 @@ module Soxi
       private
 
       def run option, remove_newlines=true
-        val = `soxi -#{option} #{filename}`
-        if remove_newlines
-          return val.gsub(/\n/,'')
+        val, std_err, status = Open3.capture3('soxi', "-#{option}", filename)
+
+        if status.success?
+          val.gsub!(/\n/,'') if remove_newlines
+          return val
+        else
+          puts "Received error status #{status.exitstatus} from soxi with message: #{std_err}"
         end
-        val
       end
     end
   end


### PR DESCRIPTION
It looks like the the run method takes the filename input and interpolates it into a backtick shell command without validating the filename. This can result in a code execution vulnerability should users of this wrapper not validate the filename (which could come from an untrusted source).

See this article for more information ([https://www.hilman.io/blog/2016/01/stop-using-backtick-to-run-shell-command-in-ruby/](https://www.hilman.io/blog/2016/01/stop-using-backtick-to-run-shell-command-in-ruby/))

This PR uses the [Open3 standard library](https://ruby-doc.org/stdlib-2.2.3/libdoc/open3/rdoc/Open3.html#method-c-popen3) to execute the command which will make sure that the parameters to the `soxi`are properly escaped. It also adds some error handling should the `soxi` binary return an error.